### PR TITLE
Do not overwrite defaultOptions in convert()

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const getMessageFormat = (
 }
 
 const convert = (parse, input, options) => {
-  options = Object.assign(defaultOptions, options)
+  options = Object.assign({}, defaultOptions, options)
   const { headers, translations } = parse(input, options.defaultCharset)
   if (!options.pluralFunction) {
     options.pluralFunction = getPluralFunction(headers['plural-forms'])


### PR DESCRIPTION
Hi there, I'm trying to use `messageformat` with PO translation files via `messageformat-po-loader`. I'm loading translations in multiple locales at the same time, and I was wondering why all the locales have the same plural function.

After an hour of debugging, I've found out – the `Object.assign` as used in `convert()` overwrites `defaultOptions` with the values from `options` of the latest call, and _returns a reference to it_ for further modification. Line 72 then effectively engraves the resolved plural function of the first loaded locale, and line 71 makes sure that this plural function is used for all other locales.

I believe this wasn't intentional :)